### PR TITLE
WIP: start of adding $has EntityFilter

### DIFF
--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -189,14 +189,14 @@ export interface IdFieldRef<entityType, valueType>
     id: valueType extends { id?: number }
       ? number
       : valueType extends { id?: string }
-      ? string
-      : string | number,
+        ? string
+        : string | number,
   ): void
   getId(): valueType extends { id?: number }
     ? number
     : valueType extends { id?: string }
-    ? string
-    : string | number
+      ? string
+      : string | number
 }
 
 export interface FieldRef<entityType = unknown, valueType = unknown>
@@ -315,8 +315,8 @@ export declare type idType<entityType> = entityType extends {
   ? U extends string
     ? string
     : U extends number
-    ? number
-    : string | number
+      ? number
+      : string | number
   : string | number
 
 export type NumericKeys<T> = {
@@ -452,8 +452,8 @@ export type GroupByResult<
     | sumFields[number]]: K extends groupByFields[number]
     ? entityType[K]
     : K extends sumFields[number]
-    ? { sum: number }
-    : never
+      ? { sum: number }
+      : never
 } & { [K in averageFields[number]]: { avg: number } } & {
   [K in minFields[number]]: { min: number }
 } & { [K in maxFields[number]]: { max: number } } & {
@@ -972,17 +972,17 @@ export declare type EntityFilter<entityType> = {
     | (Partial<entityType>[Properties] extends number | Date | undefined | null
         ? ComparisonValueFilter<Partial<entityType>[Properties]>
         : Partial<entityType>[Properties] extends string | undefined
-        ?
-            | Partial<entityType>[Properties]
-            | (ContainsStringValueFilter &
-                ComparisonValueFilter<Partial<entityType>[Properties]>)
-        : Partial<entityType>[Properties] extends boolean | undefined | null
-        ? ValueFilter<boolean>
-        : Partial<entityType>[Properties] extends
-            | { id?: string | number }
-            | undefined
-        ? IdFilter<Partial<entityType>[Properties]>
-        : ValueFilter<Partial<entityType>[Properties]>)
+          ?
+              | Partial<entityType>[Properties]
+              | (ContainsStringValueFilter &
+                  ComparisonValueFilter<Partial<entityType>[Properties]>)
+          : Partial<entityType>[Properties] extends boolean | undefined | null
+            ? ValueFilter<boolean>
+            : Partial<entityType>[Properties] extends
+                  | { id?: string | number }
+                  | undefined
+              ? IdFilter<Partial<entityType>[Properties]>
+              : ValueFilter<Partial<entityType>[Properties]>)
     | ContainsStringValueFilter
 } & {
   /**
@@ -1204,6 +1204,17 @@ export type ComparisonValueFilter<valueType> = ValueFilter<valueType> & {
   '<='?: valueType
 }
 export interface ContainsStringValueFilter {
+  /**
+   * Represents a 'HAS' filter condition where an array field must contain the specified substring.
+   *
+   * @example
+   * // Matches entities where the names[] contains 'joe'
+   * const filter = {
+   *   names: { $has: 'joe' }
+   * };
+   */
+  $has?: string
+
   /**
    * Represents a 'CONTAINS' filter condition where the value must contain the specified substring.
    *
@@ -1459,8 +1470,8 @@ export type RepositoryRelations<entityType> = {
   > extends Array<infer R>
     ? Repository<R>
     : entityType[K] extends infer R
-    ? { findOne: (options?: FindOptionsBase<R>) => Promise<R> }
-    : never
+      ? { findOne: (options?: FindOptionsBase<R>) => Promise<R> }
+      : never
 }
 
 export type RepositoryRelationsForEntityBase<entityType> = {
@@ -1469,8 +1480,8 @@ export type RepositoryRelationsForEntityBase<entityType> = {
   > extends Array<infer R>
     ? Repository<R>
     : entityType[K] extends infer R
-    ? { findOne: (options?: FindOptionsBase<R>) => Promise<R> }
-    : never
+      ? { findOne: (options?: FindOptionsBase<R>) => Promise<R> }
+      : never
 }
 
 export declare type EntityIdFields<entityType> = {
@@ -1524,8 +1535,8 @@ export const flags = {
         );
       },
     ```
-  
-  - 
+
+  -
 */
 //p1 - deleteAll({title:undefined}) should throw an error - not return 0 (with direct call to db)
 //p1 - remult-create, move db question ahead of auth - everyone needs a database, not everyone need auth


### PR DESCRIPTION
Associated with: https://discord.com/channels/975754286384418847/1358526098362732777

---

Right now it seems like if there is a `json()` field with a `string[]` in it, there cannot be a `$contains` used on the array to test for a single item.

It seems like it uses `contains` in the string-sense. So for example there is a field containing these values:

```js
values = [
  'word1',
  'word2',
  'word3
]
```

If using the `$contains` on that field, with the test string `word` ... then the row would match, because all three of those strings `contain` the string `word`

But what if the desire is for an exact match, and only an exact match?

This would be the reverse of `$in` ... which seems like it takes a single value and looks for it in an array of options which fit.

Looking for a `$has` type behavior...

---

Started a PR but by no means insightfully

Just traced through and found all instances of `$contains` and the associated function(s) and inserted equivalents for `$has` without really addressing the actual database comparison ( that's where I stopped ) since I would need to get more context first