### PR TITLE
Option to disable cache for entities and repo cache clear helpers

### DIFF
--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -140,15 +140,14 @@ export class Remult {
 
     let r = dpCache.get(entity)
     if (!r) {
-      const info = createOldEntity(entity, this)
       r = new RepositoryImplementation(
         entity,
         this,
         dataProvider,
-        info,
+        createOldEntity(entity, this),
       ) as Repository<any>
 
-      if (info.options.disableRepoCache === true) dpCache.set(entity, r)
+      if (r.metadata.options.disableRepoCache !== true) dpCache.set(entity, r)
 
       verifyFieldRelationInfo(r, this, dataProvider)
     }

--- a/projects/core/src/context.ts
+++ b/projects/core/src/context.ts
@@ -140,15 +140,15 @@ export class Remult {
 
     let r = dpCache.get(entity)
     if (!r) {
-      dpCache.set(
+      const info = createOldEntity(entity, this)
+      r = new RepositoryImplementation(
         entity,
-        (r = new RepositoryImplementation(
-          entity,
-          this,
-          dataProvider,
-          createOldEntity(entity, this),
-        ) as Repository<any>),
-      )
+        this,
+        dataProvider,
+        info,
+      ) as Repository<any>
+
+      if (info.options.disableRepoCache === true) dpCache.set(entity, r)
 
       verifyFieldRelationInfo(r, this, dataProvider)
     }
@@ -316,6 +316,37 @@ export class Remult {
   clearAllCache(): any {
     this.repCache.clear()
   }
+
+  /**
+   * Clears all cached repositories associated with a given entity for every data provider
+   * @see [Entity.disableRepoCache](https://remult.dev/docs/ref_entity#disablerepocache) to disable caching on specific entities
+   * @example
+   * import { remult } from 'remult';
+   * import { Task } from 'models/Task.js';
+   *
+   * // Clear the cached Task repositories for every data provider
+   * remult.clearEntityCache(Task);
+   */
+  clearEntityCache(entity: ClassType<any>) {
+    this.repCache.forEach((cache) => {
+      cache.delete(entity)
+    })
+  }
+
+  /**
+   * Clears all cached repositories for a given data provider
+   * @see [Entity.disableRepoCache](https://remult.dev/docs/ref_entity#disablerepocache) to disable caching on specific entities
+   * @example
+   * import { remult } from 'remult';
+   * import { postgresDP } from './dataProvider.js';
+   *
+   * // Clear the cached repositories for the postgresDP data provider
+   * remult.clearDataProviderCache(postgresDP);
+   */
+  clearDataProviderCache(dataProvider: DataProvider) {
+    this.repCache.delete(dataProvider)
+  }
+
   /** A helper callback that is called whenever an entity is created. */
   static entityRefInit?: (ref: EntityRef<any>, row: any) => void
   /** context information that can be used to store custom information that will be disposed as part of the `remult` object */

--- a/projects/core/src/entity.ts
+++ b/projects/core/src/entity.ts
@@ -246,6 +246,55 @@ export interface EntityOptions<entityType = unknown> {
   dataProvider?: (
     defaultDataProvider: DataProvider,
   ) => DataProvider | Promise<DataProvider> | undefined | null
+
+  /**
+   * Prevents entity from being cached
+   * @example
+   * import { Entity, Fields, remult, repo, withRemult } from "remult";
+   *
+   * @Entity("positions", {
+   *   // Disable repo caching for Position
+   *   disableRepoCache: true,
+   * })
+   * class Position {
+   *   @Fields.uuid()
+   *   id!: string;
+   *
+   *   @Fields.number()
+   *   x!: number;
+   *
+   *   @Fields.number()
+   *   y!: number;
+   *
+   *   @Fields.number({
+   *     async sqlExpression() {
+   *       // Assuming you've declared queryVector in RemultContext
+   *       const { x, y } = remult.context.queryVector || { x: 0, y: 0 };
+   *       // This is obviously not safe, sanitize your user inputs to avoid sql injections
+   *       return `SQRT(POWER(x - ${x}, 2) + POWER(y - ${y}, 2))`;
+   *     },
+   *   })
+   *   distance?: number;
+   * }
+   *
+   * await withRemult(
+   *   async () => {
+   *     // Thanks to `disableRepoCache: true`, sqlExpression from Position.distance will always be re-evaluated within the same remult async context
+   *     remult.context.queryVector = { x: 20, y: 30 };
+   *     const fromPoint = await repo(Position).find({
+   *       orderBy: { distance: "asc" },
+   *     });
+   *
+   *     remult.context.queryVector = { x: 0, y: 0 };
+   *     const fromOrigin = await repo(Position).find({
+   *       orderBy: { distance: "asc" },
+   *     });
+   *
+   *     console.log(fromPoint, fromOrigin);
+   *   }
+   * );
+   */
+  disableRepoCache?: boolean
 }
 
 /**

--- a/projects/core/src/remult-proxy.ts
+++ b/projects/core/src/remult-proxy.ts
@@ -94,6 +94,15 @@ export class RemultProxy implements Remult {
   clearAllCache() {
     return remultStatic.remultFactory().clearAllCache()
   }
+
+  clearDataProviderCache(dataProvider: DataProvider): void {
+    return remultStatic.remultFactory().clearDataProviderCache(dataProvider);
+  }
+
+  clearEntityCache(entity: ClassType<any>): void {
+    return remultStatic.remultFactory().clearEntityCache(entity);
+  }
+
   useFetch(args: typeof fetch) {
     return remultStatic.remultFactory().useFetch(args)
   }


### PR DESCRIPTION
Adds the entity option `disableRepoCache` to disable caching a repo within an async context

The use-case is somewhat niche, but it allows having dynamic values in some fields' `sqlExpression`

Also adds the following helper functions to `remult`:
  - `clearEntityCache(entity: ClassType<any>)` - clears all cached repos for given entity
  - `clearDataProviderCache(dataProvider: DataProvider)` - clears the cache of a given data provider