### PR TITLE
Fix for exported initAsyncHooks not enabling async storage

### DIFF
--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3823,7 +3823,7 @@ export interface RemultServerOptions<RequestType> {
     sendError: (httpStatusCode: number, body: any) => void
   }) => Promise<void> | undefined
   /**
-   * Modules are here to group code by feature.
+   * Modules are here to group code by feature. [Module Guide](https://remult.dev/docs/modules)
    *
    * @example
    * import { Module } from 'remult/server'
@@ -4060,7 +4060,7 @@ export interface RemultServerOptions<RequestType> {
     sendError: (httpStatusCode: number, body: any) => void
   }) => Promise<void> | undefined
   /**
-   * Modules are here to group code by feature.
+   * Modules are here to group code by feature. [Module Guide](https://remult.dev/docs/modules)
    *
    * @example
    * import { Module } from 'remult/server'

--- a/projects/core/async-hooks.ts
+++ b/projects/core/async-hooks.ts
@@ -1,1 +1,32 @@
-export { initAsyncHooks } from './server/initAsyncHooks.js';
+import { RemultAsyncLocalStorage } from './src/context.js'
+import { initAsyncHooks as _initAsyncHooks } from './server/initAsyncHooks.js'
+
+/**
+ * Initializes and enables async context tracking for the server.
+ *
+ * This should be called before handling any incoming requests or calling `withRemult()`.
+ * @example
+ * import { remult, repo, withRemult } from 'remult';
+ * import { initAsyncHooks } from 'remult/async-hooks';
+ *
+ * import { Task } from './entities/Task.js';
+ *
+ * initAsyncHooks();
+ *
+ * // Thx to the `initAsyncHooks` above,
+ * // we have isolated async contexts with multiple `withRemult()`,
+ * // without needing to initialize a `remultApi` all the time!
+ * withRemult(async () => {
+ *     remult.user = { id: '42' };
+ *     repo(Task).find()
+ * });
+ *
+ * withRemult(async () => {
+ *     remult.user = { id: '21' };
+ *     repo(Task).find()
+ * });
+ */
+export function initAsyncHooks() {
+  _initAsyncHooks()
+  RemultAsyncLocalStorage.enable()
+}

--- a/projects/core/server/initAsyncHooks.ts
+++ b/projects/core/server/initAsyncHooks.ts
@@ -7,31 +7,6 @@ import { remultStatic } from '../src/remult-static.js'
 
 let init = false
 
-/**
- * Initializes async context tracking for the server.
- * 
- * This should be called before handling any incoming requests or calling `withRemult()`.
- * @example
- * import { remult, repo, withRemult } from 'remult';
- * import { initAsyncHooks } from 'remult/async-hooks';
- * 
- * import { Task } from './entities/Task.js';
- * 
- * initAsyncHooks();
- * 
- * // Thx to the `initAsyncHooks` above, 
- * // we have isolated async contexts with multiple `withRemult()`, 
- * // without needing to initialize a `remultApi` all the time!
- * withRemult(async () => {
- *     remult.user = { id: '42' };
- *     repo(Task).find()
- * });
- * 
- * withRemult(async () => {
- *     remult.user = { id: '21' };
- *     repo(Task).find()
- * });
- */
 export function initAsyncHooks() {
   if (init) return
   init = true


### PR DESCRIPTION
- Added `RemultAsyncLocalStorage.enable()` to exposed `initAsyncHooks()`
- Moved jsdoc to the new `initAsyncHooks()` helper function

I've opted to keep the name `initAsyncHooks()` for the exposed function since it still fits.