### PR TITLE
Enhance documentation for value converter methods

### DIFF
--- a/docs/docs/ref_valueconverter.md
+++ b/docs/docs/ref_valueconverter.md
@@ -8,8 +8,6 @@ JSON data transfer objects (DTOs), and HTML input elements.
 Converts a value from a JSON DTO to the valueType. This method is typically used when receiving data
 from a REST API call or deserializing a JSON payload.
 
-If used on an Entity field, this method is only invoked when using the JSON database provider.
-
 #### returns:
 
 The converted value.
@@ -28,8 +26,6 @@ Arguments:
 
 Converts a value of valueType to a JSON DTO. This method is typically used when sending data
 to a REST API or serializing an object to a JSON payload.
-
-If used on an Entity field, this method is only invoked when using the JSON database provider.
 
 #### returns:
 


### PR DESCRIPTION
## Clarifying ValueConverter invocation conditions

I created Issue #797 after encountering unexpected behavior where the `fromDb()` method wasn't executing as expected. The team's explanation clarified that these converters are only invoked for persistent database providers (excluding JSON or in-memory storage).

To help others avoid similar issues, I've added notes to the documentation for `fromDb` and `fromJson`, detailing when each is triggered based on the database provider.

Before merging, I'd appreciate clarification on a few related points:

1. When and in which contexts do `fromInput()` and `toInput()` execute?
2. When and where is `displayValue()` invoked?
3. Since we already here, how do I use the `inputType()` method?
4. I've qualified the notes with "If used on an Entity field" based on my understanding that ValueConverters might apply elsewhere. Is this accurate, or are they exclusively for Entity fields?