### PR TITLE
Security: Unsanitized HTML injection in admin page template rendering

### DIFF
--- a/projects/core/server/remult-admin-html.ts
+++ b/projects/core/server/remult-admin-html.ts
@@ -4,7 +4,7 @@ import type { AdminDisplayOptions } from './remult-admin.js'
 export default function remultAdminHtml(options: AdminDisplayOptions) {
   const { head, rootPath, requireAuthToken, disableLiveQuery } = options
   return getHtml()
-    .replace('<!--PLACE_HERE_HEAD-->', head)
+    .replace('<!--PLACE_HERE_HEAD-->', sanitizeHead(head))
     .replace(
       '<!--PLACE_HERE_BODY-->',
       `<script>
@@ -13,6 +13,15 @@ export default function remultAdminHtml(options: AdminDisplayOptions) {
     requireAuthToken,
     disableLiveQuery,
   })}
+
+function sanitizeHead(head: string | undefined) {
+  return (head ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
 </script>`,
     )
 }


### PR DESCRIPTION
## Problem

The `head` option is interpolated directly into HTML via string replacement without sanitization. If `head` can be influenced by untrusted input, this enables stored/reflected XSS in the admin UI.

**Severity**: `high`
**File**: `projects/core/server/remult-admin-html.ts`

## Solution

Sanitize or strictly validate `head` before insertion, or avoid raw HTML insertion entirely. Prefer a safe templating approach that escapes by default.

## Changes

- `projects/core/server/remult-admin-html.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
