### PR TITLE
Security: Administrative API enabled without access controls in template

### DIFF
--- a/projects/create-remult/templates/nuxt/server/api/[...remult].ts
+++ b/projects/create-remult/templates/nuxt/server/api/[...remult].ts
@@ -11,7 +11,7 @@ class Task {
 
 export const api = remultApi({
   entities: [Task],
-  admin: true,
+  admin: false,
 });
 
 export default defineEventHandler(api);


### PR DESCRIPTION
## Problem

`admin: true` is enabled in a generated Nuxt API template. If used as-is, this can expose powerful admin endpoints to unauthenticated users depending on deployment configuration.

**Severity**: `high`
**File**: `projects/create-remult/templates/nuxt/server/api/[...remult].ts`

## Solution

Disable `admin` by default in templates, or gate admin routes behind strict authentication/authorization checks.

## Changes

- `projects/create-remult/templates/nuxt/server/api/[...remult].ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
