### PR TITLE
feat(live-query): applyChanges pos option

### DIFF
--- a/.claude/skills/remult/SKILL.md
+++ b/.claude/skills/remult/SKILL.md
@@ -348,6 +348,18 @@ export class Comment extends Auditable {
 
 For shared _options_ (permissions, hooks), extract a typed helper returning `EntityOptions<T>` and spread it into each `@Entity({...})`.
 
+## Live Queries
+
+`repo.liveQuery(options).subscribe(info => ...)` streams realtime updates over SSE. Same `find` options (`where`, `orderBy`, `limit`...). Use `info.applyChanges(prevState)` to fold changes into your existing array - it keeps the array sorted like `info.items`. `subscribe` returns an unsubscribe fn. See <https://remult.dev/docs/live-queries>.
+
+```ts
+const unsub = repo
+  .liveQuery({ orderBy: { createdAt: 'desc' } })
+  .subscribe((info) => setTasks(info.applyChanges))
+```
+
+`applyChanges(prev, { pos })` - `pos: 'first' | 'last'` overrides placement of added items (default `'auto'` re-sorts).
+
 ## Module Pattern
 
 Bundle related entities + init logic into a module so apps register them in one line. See <https://remult.dev/docs/modules>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- `LiveQueryChangeInfo.applyChanges` now keeps the array ordered by the query's `orderBy` (or the entity's `defaultOrderBy`) by default, and accepts a `{ pos: 'auto' | 'first' | 'last' }` option to control placement of added items.
+
 ## [3.3.13] - 2026-06-09
 
 - Fixed `groupBy`/`aggregate` with `limit`/`page` but no `orderBy` emitting `OFFSET/FETCH` without an `ORDER BY`, which is invalid on SQL Server. A grouped query now falls back to ordering by the group columns, and a pure aggregate skips paging entirely.

--- a/docs/docs/ref_livequerychangeinfo.md
+++ b/docs/docs/ref_livequerychangeinfo.md
@@ -1,31 +1,43 @@
 # LiveQueryChangeInfo
+
 The `LiveQueryChangeInfo` interface represents information about changes in the results of a live query.
+
 ## items
+
 The updated array of result items.
+
 ## changes
+
 The changes received in the specific message. The change types can be "all" (replace all), "add", "replace", or "remove".
+
 ## applyChanges
+
 Applies the changes received in the message to an existing array. This method is particularly useful with React
 to update the component's state based on the live query changes.
 
-
 #### returns:
+
 The updated array of result items after applying the changes.
 
-
 #### example:
+
 ```ts
 // Using applyChanges in a React component with useEffect hook
 useEffect(() => {
   return taskRepo
     .liveQuery({
       limit: 20,
-      orderBy: { createdAt: 'asc' }
+      orderBy: { createdAt: 'asc' },
       //where: { completed: true },
     })
-    .subscribe(info => setTasks(info.applyChanges));
-}, []);
+    .subscribe((info) => setTasks(info.applyChanges))
+}, [])
 ```
 
 Arguments:
-* **prevState** - The previous state of the array of result items.
+
+- **prevState** - The previous state of the array of result items.
+- **options** - Controls where added items are placed.
+  `'auto'` (default) keeps the array sorted by the query's `orderBy` (or the entity's `defaultOrderBy`, falling back to `'last'` when neither is set);
+  `'first'` prepends added items; `'last'` appends them.
+  - **pos**

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -2143,6 +2143,9 @@ export interface LiveQueryChangeInfo<entityType> {
    * to update the component's state based on the live query changes.
    *
    * @param {entityType[] | undefined} prevState The previous state of the array of result items.
+   * @param {{ pos?: 'auto' | 'first' | 'last' }} [options] Controls where added items are placed.
+   * `'auto'` (default) keeps the array sorted by the query's `orderBy` (or the entity's `defaultOrderBy`, falling back to `'last'` when neither is set);
+   * `'first'` prepends added items; `'last'` appends them.
    * @returns {entityType[]} The updated array of result items after applying the changes.
    *
    * @example
@@ -2157,7 +2160,12 @@ export interface LiveQueryChangeInfo<entityType> {
    *     .subscribe(info => setTasks(info.applyChanges));
    * }, []);
    */
-  applyChanges(prevState: entityType[] | undefined): entityType[]
+  applyChanges(
+    prevState: entityType[] | undefined,
+    options?: {
+      pos?: "auto" | "first" | "last"
+    },
+  ): entityType[]
 }
 export interface LiveQueryStorage {
   add(query: StoredQuery): Promise<void>

--- a/projects/core/src/live-query/SubscriptionChannel.ts
+++ b/projects/core/src/live-query/SubscriptionChannel.ts
@@ -43,20 +43,31 @@ export class LiveQuerySubscriber<entityType> {
     ]
   }
 
+  // the order the query's results actually come back in: the explicit orderBy,
+  // falling back to the entity's defaultOrderBy
+  private effectiveOrderBy() {
+    return (
+      this.query.options.orderBy ?? this.repo.metadata.options.defaultOrderBy
+    )
+  }
+
   forListeners(
     what: (
-      listener: (reducer: (prevState: entityType[]) => entityType[]) => void,
+      listener: (
+        reducer: (
+          prevState: entityType[],
+          options?: { pos?: 'auto' | 'first' | 'last' },
+        ) => entityType[],
+      ) => void,
     ) => void,
     changes: LiveQueryChange[],
   ) {
     what((reducer) => {
       this.defaultQueryState = reducer(this.defaultQueryState)
       if (changes.find((c) => c.type === 'add' || c.type === 'replace')) {
-        if (this.query.options.orderBy) {
-          const o = Sort.translateOrderByToSort(
-            this.repo.metadata,
-            this.query.options.orderBy,
-          )
+        const orderBy = this.effectiveOrderBy()
+        if (orderBy) {
+          const o = Sort.translateOrderByToSort(this.repo.metadata, orderBy)
           this.defaultQueryState.sort((a: any, b: any) => o.compare(a, b))
         }
       }
@@ -70,7 +81,10 @@ export class LiveQuerySubscriber<entityType> {
   }
 
   private createReducerType(
-    applyChanges: (prevState: entityType[]) => entityType[],
+    applyChanges: (
+      prevState: entityType[],
+      options?: { pos?: 'auto' | 'first' | 'last' },
+    ) => entityType[],
     changes: LiveQueryChange[],
   ): LiveQueryChangeInfo<entityType> {
     return {
@@ -94,14 +108,17 @@ export class LiveQuerySubscriber<entityType> {
     }
 
     this.forListeners((listener) => {
-      listener((items) => {
+      listener((items, options) => {
+        const pos = options?.pos ?? 'auto'
         if (!items) items = []
+        let addedOrReplaced = false
         for (const message of messages) {
           switch (message.type) {
             case 'all':
               this.setAllItems(message.data)
               break
             case 'replace': {
+              addedOrReplaced = true
               items = items.map((x) =>
                 this.repo.metadata.idMetadata.getId(x) === message.data.oldId
                   ? message.data.item
@@ -110,12 +127,14 @@ export class LiveQuerySubscriber<entityType> {
               break
             }
             case 'add':
+              addedOrReplaced = true
               items = items.filter(
                 (x) =>
                   this.repo.metadata.idMetadata.getId(x) !==
                   this.repo.metadata.idMetadata.getId(message.data.item),
               )
-              items.push(message.data.item)
+              if (pos === 'first') items = [message.data.item, ...items]
+              else items = [...items, message.data.item]
               break
             case 'remove':
               items = items.filter(
@@ -124,6 +143,14 @@ export class LiveQuerySubscriber<entityType> {
               )
               break
           }
+        }
+        // 'auto' keeps the array ordered like `info.items` (the query's orderBy,
+        // or the entity's defaultOrderBy); explicit 'first'/'last' leave
+        // placement untouched
+        const orderBy = pos === 'auto' && this.effectiveOrderBy()
+        if (orderBy && addedOrReplaced) {
+          const o = Sort.translateOrderByToSort(this.repo.metadata, orderBy)
+          items = [...items].sort((a: any, b: any) => o.compare(a, b))
         }
         return items
       })

--- a/projects/core/src/remult3/remult3.ts
+++ b/projects/core/src/remult3/remult3.ts
@@ -949,6 +949,9 @@ export interface LiveQueryChangeInfo<entityType> {
    * to update the component's state based on the live query changes.
    *
    * @param {entityType[] | undefined} prevState The previous state of the array of result items.
+   * @param {{ pos?: 'auto' | 'first' | 'last' }} [options] Controls where added items are placed.
+   * `'auto'` (default) keeps the array sorted by the query's `orderBy` (or the entity's `defaultOrderBy`, falling back to `'last'` when neither is set);
+   * `'first'` prepends added items; `'last'` appends them.
    * @returns {entityType[]} The updated array of result items after applying the changes.
    *
    * @example
@@ -963,7 +966,10 @@ export interface LiveQueryChangeInfo<entityType> {
    *     .subscribe(info => setTasks(info.applyChanges));
    * }, []);
    */
-  applyChanges(prevState: entityType[] | undefined): entityType[]
+  applyChanges(
+    prevState: entityType[] | undefined,
+    options?: { pos?: 'auto' | 'first' | 'last' },
+  ): entityType[]
 }
 export interface FindOptions<entityType> extends FindOptionsBase<entityType> {
   /** Number of rows returned. _(Defaults to 100 in the browser)_

--- a/projects/tests/tests/live-query-tests.spec.ts
+++ b/projects/tests/tests/live-query-tests.spec.ts
@@ -13,7 +13,7 @@ import {
   LiveQueryPublisher,
 } from '../../core/src/live-query/SubscriptionServer'
 import { remult } from '../../core/src/remult-proxy'
-import type { FindOptions } from '../../core'
+import type { ClassType, FindOptions } from '../../core'
 import { Entity, Fields, Relations, getEntityRef } from '../../core'
 
 import { createMockHttpDataProvider } from '../tests/testHelper'
@@ -52,6 +52,16 @@ export class Category {
   id = 0
   @Fields.string()
   name = ''
+}
+@Entity<defaultOrderByEntity>('default-order-by-test', {
+  allowApiCrud: true,
+  defaultOrderBy: { title: 'desc' },
+})
+export class defaultOrderByEntity {
+  @Fields.integer()
+  id = 0
+  @Fields.string()
+  title = ''
 }
 
 async function setup1() {
@@ -319,12 +329,14 @@ describe('test live query full cycle', () => {
   afterEach(() => {
     queryConfig.defaultPageSize = 2
   })
-  function setup2() {
+  function setup2<T = eventTestEntity>(
+    entity: ClassType<T> = eventTestEntity as any,
+  ) {
     const mem = new InMemoryDataProvider()
     const remult = new Remult(mem)
-    const repo = remult.repo(eventTestEntity)
+    const repo = remult.repo(entity)
     const remult2 = new Remult(mem)
-    const repo2 = remult2.repo(eventTestEntity)
+    const repo2 = remult2.repo(entity)
 
     const mh: ((channel: string, message: LiveQueryChange) => void)[] = []
     let messageCount = 0
@@ -512,7 +524,59 @@ describe('test live query full cycle', () => {
     await pm.flush()
     await repo2.insert({ id: 2, title: 'yael' })
     await pm.flush()
-    expect(result1.map((r) => r.id)).toEqual([1, 2])
+    // applyChanges now keeps the array ordered by orderBy by default ('auto'),
+    // so it matches info.items (title desc => yael, noam)
+    expect(result1.map((r) => r.id)).toEqual([2, 1])
+    expect(items.map((r) => r.id)).toEqual([2, 1])
+    u()
+  })
+  it('test applyChanges pos option overrides ordering', async () => {
+    var { repo, pm, repo2 } = setup2()
+    let auto: eventTestEntity[] = []
+    let last: eventTestEntity[] = []
+    let first: eventTestEntity[] = []
+    const u = repo
+      .liveQuery({
+        orderBy: { title: 'desc' },
+      })
+      .subscribe((info) => {
+        auto = info.applyChanges(auto)
+        last = info.applyChanges(last, { pos: 'last' })
+        first = info.applyChanges(first, { pos: 'first' })
+      })
+    await pm.flush()
+    await repo.insert({ id: 1, title: 'noam' })
+    await pm.flush()
+    await repo2.insert({ id: 2, title: 'yael' })
+    await pm.flush()
+    await repo.insert({ id: 3, title: 'abc' })
+    await pm.flush()
+    // 'auto' (default): ordered by title desc -> yael, noam, abc
+    expect(auto.map((r) => r.id)).toEqual([2, 1, 3])
+    // 'last': appended in arrival order
+    expect(last.map((r) => r.id)).toEqual([1, 2, 3])
+    // 'first': each added item prepended
+    expect(first.map((r) => r.id)).toEqual([3, 2, 1])
+    u()
+  })
+  it('test applyChanges falls back to entity defaultOrderBy', async () => {
+    var { repo, pm, repo2 } = setup2(defaultOrderByEntity)
+    let result1: defaultOrderByEntity[] = []
+    let items: defaultOrderByEntity[] = []
+    const u = repo
+      // no explicit orderBy -> uses the entity's defaultOrderBy { title: 'desc' }
+      .liveQuery({})
+      .subscribe((info) => {
+        result1 = info.applyChanges(result1)
+        items = info.items
+      })
+    await pm.flush()
+    await repo.insert({ id: 1, title: 'noam' })
+    await pm.flush()
+    await repo2.insert({ id: 2, title: 'yael' })
+    await pm.flush()
+    // title desc => yael(2), noam(1)
+    expect(result1.map((r) => r.id)).toEqual([2, 1])
     expect(items.map((r) => r.id)).toEqual([2, 1])
     u()
   })

--- a/projects/tests/tests/test-paged-foreach.spec.ts
+++ b/projects/tests/tests/test-paged-foreach.spec.ts
@@ -229,6 +229,17 @@ function testPaging(
       expect((await p.getPage()).map((x) => x.id)).toEqual([1, 2, 3])
       expect((await p.getPage(2)).map((x) => x.id)).toEqual([4, 5])
     })
+    // NOTE: `hasNextPage` is derived purely from the page that was fetched:
+    // `hasNextPage === (items.length === pageSize)`. The paginator deliberately
+    // fetches exactly `pageSize` rows, so when the total count is an exact
+    // multiple of the page size it cannot know the next page is empty without
+    // paying for it. The trade-off (cheaper: no extra row, no extra COUNT query)
+    // is one "phantom" `hasNextPage === true` on the last full page: navigating
+    // to it returns an empty page and `hasNextPage` then becomes false.
+    //
+    // If you need an exact "is this the last page" on the client and you already
+    // have the total (e.g. you called `count()`), compute it yourself, e.g.
+    // `hasNextPageClient = loadedSoFar < total`.
     it('paginate on boundries', async () => {
       const [c] = await createData(async (insert) => {
         await insert(1, 'noam')
@@ -243,6 +254,7 @@ function testPaging(
       expect(p.hasNextPage).toBe(true)
       p = await p.nextPage()
       expect(p.items.map((x) => x.id)).toEqual([3, 4])
+      // phantom next page: total (4) is an exact multiple of pageSize (2)
       expect(p.hasNextPage).toBe(true)
       p = await p.nextPage()
       expect(p.items.map((x) => x.id)).toEqual([])


### PR DESCRIPTION
`info.applyChanges(prev, { pos })` controls placement of added items:

- `'auto'` (default) keeps the array sorted by the query's `orderBy` (or the entity's `defaultOrderBy`)
- `'first'` / `'last'` prepend / append

Note that it's a change because before, the "default" was `last`

---

What do you think?
_(In the end, I don't need pagination & previous! lol. I also don't NEED this, but could be nice!)_