### PR TITLE
feat: add Node built-in SQLite data provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,24 @@ jobs:
       - store_test_results:
           path: ./test-results.xml
 
+  test-node-sqlite:
+    docker:
+      - image: cimg/node:24.11
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Run node:sqlite provider tests with coverage
+          command: npx vitest run projects/tests/dbs/node-sqlite.spec.ts --coverage
+      - run:
+          name: Upload coverage to Codecov
+          command: |
+            curl -Os https://cli.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov upload-process -t "$CODECOV_TOKEN" || true
+      - store_test_results:
+          path: ./test-results.xml
+
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
@@ -65,3 +83,4 @@ workflows:
     jobs:
       - build
       - test-remult
+      - test-node-sqlite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,25 @@ on:
       - '**'
 
 jobs:
+  node_sqlite:
+    name: Node built-in SQLite provider
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🌐 Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: 🧑‍💻 Setup env
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: 📦 Install dependencies
+        run: npm ci
+
+      - name: 🧪 Test node:sqlite provider
+        run: npx vitest run projects/tests/dbs/node-sqlite.spec.ts --coverage=false
+
   build:
     name: Test latest typescript build with public api
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,25 +9,6 @@ on:
       - '**'
 
 jobs:
-  node_sqlite:
-    name: Node built-in SQLite provider
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: 🌐 Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: 🧑‍💻 Setup env
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      - name: 📦 Install dependencies
-        run: npm ci
-
-      - name: 🧪 Test node:sqlite provider
-        run: npx vitest run projects/tests/dbs/node-sqlite.spec.ts --coverage=false
-
   build:
     name: Test latest typescript build with public api
     runs-on: ubuntu-latest

--- a/docs/docs/installation/database/index.md
+++ b/docs/docs/installation/database/index.md
@@ -1,5 +1,5 @@
 ---
-llm: "Database picker - defaults to a JSON file store in ./db when no dataProvider is configured."
+llm: 'Database picker - defaults to a JSON file store in ./db when no dataProvider is configured.'
 ---
 
 <script setup>
@@ -14,7 +14,7 @@ By default, if no database provider is specified, Remult will use a simple JSON 
 	<Icon tech="postgres" sizeIco=100 link="/docs/installation/database/postgresql" />
 	<Icon tech="mysql" sizeIco=100 link="/docs/installation/database/mysql" />
 	<Icon tech="mongodb" sizeIco=100 link="/docs/installation/database/mongodb" />
-	<Icon tech="sqlite" sizeIco=100 link="/docs/installation/database/better-sqlite3" />
+	<Icon tech="sqlite" sizeIco=100 link="/docs/installation/database/node-sqlite" />
 	<Icon tech="sqljs" sizeIco=100 link="/docs/installation/database/sqljs" />
 	<Icon tech="mssql" sizeIco=100 link="/docs/installation/database/mssql" />
 	<Icon tech="bun-sqlite" sizeIco=100 link="/docs/installation/database/bun-sqlite" />

--- a/docs/docs/installation/database/node-sqlite.md
+++ b/docs/docs/installation/database/node-sqlite.md
@@ -1,0 +1,32 @@
+---
+llm: "Node's built-in SQLite via NodeSqliteDataProvider wrapped in SqlDatabase on the dataProvider option."
+---
+
+### Node SQLite
+
+Node.js 22.5.0 and newer include a synchronous SQLite implementation in the
+built-in `node:sqlite` module. No database driver package is required.
+
+Configure the `dataProvider` in your `api.ts` or server file:
+
+```ts
+import express from 'express'
+import { DatabaseSync } from 'node:sqlite'
+import { SqlDatabase } from 'remult'
+import { remultApi } from 'remult/remult-express'
+import { NodeSqliteDataProvider } from 'remult/remult-node-sqlite'
+
+const app = express()
+
+app.use(
+  remultApi({
+    dataProvider: new SqlDatabase(
+      new NodeSqliteDataProvider(new DatabaseSync('./mydb.sqlite')),
+    ),
+  }),
+)
+```
+
+`DatabaseSync` serializes access within the Node.js process. A file-backed
+SQLite database should normally be used by a single application instance unless
+the deployment architecture provides its own coordination.

--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -37,7 +37,7 @@ llm: false # nav stub - children are listed directly in llms.txt
 	<Icon tech="postgres" sizeIco=100 link="/docs/installation/database/postgresql" />
 	<Icon tech="mysql" sizeIco=100 link="/docs/installation/database/mysql" />
 	<Icon tech="mongodb" sizeIco=100 link="/docs/installation/database/mongodb" />
-	<Icon tech="sqlite" sizeIco=100 link="/docs/installation/database/better-sqlite3" />
+	<Icon tech="sqlite" sizeIco=100 link="/docs/installation/database/node-sqlite" />
 	<Icon tech="sqljs" sizeIco=100 link="/docs/installation/database/sqljs" />
 	<Icon tech="mssql" sizeIco=100 link="/docs/installation/database/mssql" />
 	<Icon tech="bun-sqlite" sizeIco=100 link="/docs/installation/database/bun-sqlite" />

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -4611,6 +4611,22 @@ export declare class SqliteCoreDataProvider
 //[ ] FieldMetadata from ./src/column-interfaces.js is not exported
 ```
 
+## ./remult-node-sqlite.js
+
+```ts
+export type NodeSqliteDatabase = {
+  prepare(sql: string): NodeSqliteStatement
+  close(): void
+}
+export declare class NodeSqliteDataProvider extends SqliteCoreDataProvider {
+  constructor(db: NodeSqliteDatabase)
+}
+export type NodeSqliteStatement = {
+  setAllowBareNamedParameters(enabled: boolean): void
+  all(...anonymousParameters: any[]): Record<string, unknown>[]
+}
+```
+
 ## ./remult-better-sqlite3.js
 
 ```ts

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -44,6 +44,7 @@
     "./remult-mongo": "./remult-mongo.js",
     "./remult-sql-js": "./remult-sql-js.js",
     "./remult-sqlite-core-js": "./remult-sqlite-core.js",
+    "./remult-node-sqlite": "./remult-node-sqlite.js",
     "./remult-better-sqlite3": "./remult-better-sqlite3.js",
     "./remult-sqlite3": "./remult-sqlite3.js",
     "./remult-turso": "./remult-turso.js",

--- a/projects/core/remult-node-sqlite.ts
+++ b/projects/core/remult-node-sqlite.ts
@@ -1,0 +1,72 @@
+import { SqliteCoreDataProvider } from './remult-sqlite-core.js'
+import type { SqlCommand, SqlResult } from './src/sql-command.js'
+
+export type NodeSqliteStatement = {
+  setAllowBareNamedParameters(enabled: boolean): void
+  all(...anonymousParameters: any[]): Record<string, unknown>[]
+}
+
+export type NodeSqliteDatabase = {
+  prepare(sql: string): NodeSqliteStatement
+  close(): void
+}
+
+/**
+ * A Remult data provider for Node's built-in `node:sqlite` module.
+ *
+ * `node:sqlite` is available in Node.js 22.5.0 and newer. The database is
+ * accepted structurally so importing this adapter does not load a Node-only
+ * module until the application creates its `DatabaseSync` instance.
+ */
+export class NodeSqliteDataProvider extends SqliteCoreDataProvider {
+  constructor(db: NodeSqliteDatabase) {
+    super(
+      () => new NodeSqliteCommand(db),
+      async () => {
+        db.close()
+      },
+    )
+  }
+}
+
+class NodeSqliteCommand implements SqlCommand {
+  private values: Record<string, unknown> = {}
+  private i = 0
+
+  constructor(private db: NodeSqliteDatabase) {}
+
+  async execute(sql: string): Promise<SqlResult> {
+    const statement = this.db.prepare(sql)
+    statement.setAllowBareNamedParameters(true)
+    const rows = Object.keys(this.values).length
+      ? statement.all(this.values)
+      : statement.all()
+    return new NodeSqliteResult(rows)
+  }
+
+  addParameterAndReturnSqlToken(value: any): string {
+    return this.param(value)
+  }
+
+  param(value: any): string {
+    if (value instanceof Date) value = value.valueOf()
+    if (typeof value === 'boolean') value = value ? 1 : 0
+    if (value === undefined) value = null
+    const key = String(this.i++)
+    this.values[key] = value
+    return `:${key}`
+  }
+}
+
+class NodeSqliteResult implements SqlResult {
+  rows: Record<string, unknown>[]
+
+  constructor(rows: Record<string, unknown>[]) {
+    this.rows = rows
+  }
+
+  getColumnKeyInResultForIndexInSelect(index: number): string {
+    const first = this.rows[0]
+    return first ? (Object.keys(first)[index] ?? '') : ''
+  }
+}

--- a/projects/tests/dbs/node-sqlite.spec.ts
+++ b/projects/tests/dbs/node-sqlite.spec.ts
@@ -1,0 +1,72 @@
+import { createRequire } from 'node:module'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { Remult, SqlDatabase } from '../../core'
+import {
+  NodeSqliteDataProvider,
+  type NodeSqliteDatabase,
+} from '../../core/remult-node-sqlite.js'
+import type { DbTestProps } from './shared-tests/db-tests-props.js'
+import { allDbTests } from './shared-tests/index.js'
+import { SqlDbTests } from './shared-tests/sql-db-tests.js'
+
+const require = createRequire(import.meta.url)
+const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(Number)
+const supportsNodeSqlite =
+  nodeMajor > 22 || (nodeMajor === 22 && nodeMinor >= 5)
+
+describe.skipIf(!supportsNodeSqlite)('node:sqlite', () => {
+  let db: SqlDatabase
+  let remult: Remult
+
+  beforeEach(() => {
+    const { DatabaseSync } = require('node:sqlite') as {
+      DatabaseSync: new (location: string) => NodeSqliteDatabase
+    }
+    db = new SqlDatabase(
+      new NodeSqliteDataProvider(new DatabaseSync(':memory:')),
+    )
+    remult = new Remult(db)
+  })
+
+  const props: DbTestProps = {
+    getDb() {
+      return db
+    },
+    getRemult() {
+      return remult
+    },
+    createEntity: async (entity) => {
+      const repo = remult.repo(entity)
+      await db.ensureSchema([repo.metadata])
+      return repo
+    },
+  }
+
+  allDbTests(props)
+  SqlDbTests({ ...props })
+
+  it('executes statements and named parameters', async () => {
+    await db.execute('create table x (id int)')
+    await db.execute('insert into x values (1)')
+    expect((await db.execute('select * from x')).rows).toEqual([{ id: 1 }])
+
+    const command = db.createCommand()
+    expect(
+      (await command.execute(`select * from x where id=${command.param(1)}`))
+        .rows,
+    ).toEqual([{ id: 1 }])
+  })
+
+  it('round-trips binary values', async () => {
+    await db.execute('create table binary_values (id int, value blob)')
+    const command = db.createCommand()
+    await command.execute(
+      `insert into binary_values values (${command.param(1)}, ${command.param(
+        new Uint8Array([1, 2, 3]),
+      )})`,
+    )
+
+    const rows = (await db.execute('select value from binary_values')).rows
+    expect(rows[0].value).toEqual(new Uint8Array([1, 2, 3]))
+  })
+})

--- a/projects/tests/dbs/node-sqlite.spec.ts
+++ b/projects/tests/dbs/node-sqlite.spec.ts
@@ -17,14 +17,14 @@ const supportsNodeSqlite =
 describe.skipIf(!supportsNodeSqlite)('node:sqlite', () => {
   let db: SqlDatabase
   let remult: Remult
+  let provider: NodeSqliteDataProvider
 
   beforeEach(() => {
     const { DatabaseSync } = require('node:sqlite') as {
       DatabaseSync: new (location: string) => NodeSqliteDatabase
     }
-    db = new SqlDatabase(
-      new NodeSqliteDataProvider(new DatabaseSync(':memory:')),
-    )
+    provider = new NodeSqliteDataProvider(new DatabaseSync(':memory:'))
+    db = new SqlDatabase(provider)
     remult = new Remult(db)
   })
 
@@ -55,6 +55,16 @@ describe.skipIf(!supportsNodeSqlite)('node:sqlite', () => {
       (await command.execute(`select * from x where id=${command.param(1)}`))
         .rows,
     ).toEqual([{ id: 1 }])
+
+    const legacyCommand = provider.createCommand()
+    const legacyParameter = legacyCommand.addParameterAndReturnSqlToken(1)
+    expect(
+      (
+        await legacyCommand.execute(
+          `select * from x where id=${legacyParameter}`,
+        )
+      ).rows,
+    ).toEqual([{ id: 1 }])
   })
 
   it('round-trips binary values', async () => {
@@ -68,5 +78,11 @@ describe.skipIf(!supportsNodeSqlite)('node:sqlite', () => {
 
     const rows = (await db.execute('select value from binary_values')).rows
     expect(rows[0].value).toEqual(new Uint8Array([1, 2, 3]))
+  })
+
+  it('closes the underlying database', async () => {
+    await db.end()
+
+    await expect(db.execute('select 1')).rejects.toThrow()
   })
 })


### PR DESCRIPTION
## Summary

- add a dependency-free `NodeSqliteDataProvider` for Node's built-in `node:sqlite` module
- expose it through `remult/remult-node-sqlite` and document the Node 22.5+ setup
- run the shared Remult SQL-provider contract in a dedicated Node 24 CI job
- keep Node 20 consumers safe by avoiding a static `node:sqlite` import in the adapter

## Verification

- `npx -y -p node@24 node node_modules/vitest/vitest.mjs run projects/tests/dbs/node-sqlite.spec.ts --coverage=false` (160 passed)
- `npx -y -p node@24 node /opt/homebrew/lib/node_modules/npm/bin/npm-cli.js run build`
- `npx -y -p node@20 node node_modules/vitest/vitest.mjs run projects/tests/dbs/node-sqlite.spec.ts --coverage=false` (suite skipped as designed)