### PR TITLE
refactor: contract-based route registration for subscription servers

### DIFF
--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3979,8 +3979,11 @@ export type SpecificRoute<RequestType> = {
     handler: GenericRequestHandler<RequestType>,
   ): SpecificRoute<RequestType>
 }
-export declare class SseSubscriptionServer implements SubscriptionServer {
+export declare class SseSubscriptionServer
+  implements SubscriptionServerWithRoutes
+{
   private canUserConnectToChannel?
+  initApiServer(api: SubscriptionServerRouteApi): void
   constructor(
     canUserConnectToChannel?:
       | ((channel: string, remult: Remult) => boolean)
@@ -3988,6 +3991,7 @@ export declare class SseSubscriptionServer implements SubscriptionServer {
   )
   publishMessage<T>(channel: string, message: any): Promise<void>
 }
+//[ ] SubscriptionServerRouteApi from TBD is not exported
 export declare function TestApiDataProvider(
   options?: Pick<RemultServerOptions<unknown>, "ensureSchema" | "dataProvider">,
 ): RestDataProvider
@@ -4221,8 +4225,11 @@ export type SpecificRoute<RequestType> = {
     handler: GenericRequestHandler<RequestType>,
   ): SpecificRoute<RequestType>
 }
-export declare class SseSubscriptionServer implements SubscriptionServer {
+export declare class SseSubscriptionServer
+  implements SubscriptionServerWithRoutes
+{
   private canUserConnectToChannel?
+  initApiServer(api: SubscriptionServerRouteApi): void
   constructor(
     canUserConnectToChannel?:
       | ((channel: string, remult: Remult) => boolean)
@@ -4230,6 +4237,7 @@ export declare class SseSubscriptionServer implements SubscriptionServer {
   )
   publishMessage<T>(channel: string, message: any): Promise<void>
 }
+//[ ] SubscriptionServerRouteApi from TBD is not exported
 ```
 
 ## ./remult-fastify.js
@@ -4867,6 +4875,20 @@ export declare class controllerRefImpl<T = unknown>
 //[ ] FieldMetadata from TBD is not exported
 //[ ] Remult from TBD is not exported
 //[ ] FieldsRef from TBD is not exported
+export interface DataApiResponse {
+  success(data: any): void
+  deleted(): void
+  created(data: any): void
+  notFound(): void
+  error(
+    data: ErrorInfo,
+    entity: EntityMetadata | undefined,
+    statusCode?: number | undefined,
+  ): void
+  forbidden(message?: string): void
+  progress(progress: number): void
+}
+//[ ] ErrorInfo from TBD is not exported
 export declare class DataProviderPromiseWrapper implements DataProvider {
   private dataProvider
   constructor(dataProvider: Promise<DataProvider>)
@@ -4957,6 +4979,26 @@ export declare function sqlRelationsFilter<entityType>(
     p,
     ArrayItemType<NonNullable<entityType[p]>>
   >
+}
+export interface SubscriptionServerRouteApi {
+  rootPath: string
+  addRoute(
+    relativePath: string,
+    method: "get" | "post",
+    handler: (args: SubscriptionServerRouteHandlerArgs) => Promise<void>,
+  ): void
+}
+export interface SubscriptionServerRouteHandlerArgs {
+  remult: Remult
+  res: DataApiResponse
+  req: GenericRequestInfo
+  origRes: GenericResponse
+  getBody(): Promise<any>
+}
+//[ ] GenericRequestInfo from TBD is not exported
+//[ ] GenericResponse from TBD is not exported
+export interface SubscriptionServerWithRoutes extends SubscriptionServer {
+  initApiServer(api: SubscriptionServerRouteApi): void
 }
 ```
 

--- a/misc/public-api.md
+++ b/misc/public-api.md
@@ -3267,7 +3267,11 @@ export interface SubscriptionListener<type> {
 }
 export interface SubscriptionServer {
   publishMessage<T>(channel: string, message: T): Promise<void>
+  /** A subscription server that also needs to serve http routes (for example SSE),
+   * can implement this method to register them on the api server */
+  initApiServer?(api: SubscriptionServerRouteApi): void
 }
+//[ ] SubscriptionServerRouteApi from TBD is not exported
 export type Unsubscribe = VoidFunction
 export interface UpsertOptions<entityType> {
   where: Partial<MembersOnly<entityType>>
@@ -3979,9 +3983,7 @@ export type SpecificRoute<RequestType> = {
     handler: GenericRequestHandler<RequestType>,
   ): SpecificRoute<RequestType>
 }
-export declare class SseSubscriptionServer
-  implements SubscriptionServerWithRoutes
-{
+export declare class SseSubscriptionServer implements SubscriptionServer {
   private canUserConnectToChannel?
   initApiServer(api: SubscriptionServerRouteApi): void
   constructor(
@@ -4225,9 +4227,7 @@ export type SpecificRoute<RequestType> = {
     handler: GenericRequestHandler<RequestType>,
   ): SpecificRoute<RequestType>
 }
-export declare class SseSubscriptionServer
-  implements SubscriptionServerWithRoutes
-{
+export declare class SseSubscriptionServer implements SubscriptionServer {
   private canUserConnectToChannel?
   initApiServer(api: SubscriptionServerRouteApi): void
   constructor(
@@ -4997,9 +4997,6 @@ export interface SubscriptionServerRouteHandlerArgs {
 }
 //[ ] GenericRequestInfo from TBD is not exported
 //[ ] GenericResponse from TBD is not exported
-export interface SubscriptionServerWithRoutes extends SubscriptionServer {
-  initApiServer(api: SubscriptionServerRouteApi): void
-}
 ```
 
 ## ./remult-nuxt.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remult-mono-repo",
-  "version": "3.3.16",
+  "version": "3.3.17-next.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remult-mono-repo",
-      "version": "3.3.16",
+      "version": "3.3.17-next.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250613.0",
         "@duckdb/node-api": "^1.3.2-alpha.26",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remult-mono-repo",
   "description": "See projects/core for the remult core package.json. This package.json is used for remult/core development, test projects and experimental work. See ",
-  "version": "3.3.16",
+  "version": "3.3.17-next.0",
   "scripts": {
     "format": "prettier \"./projects/core/**\" --write",
     "test": "vitest --ui --coverage",

--- a/projects/core/SseSubscriptionServer.ts
+++ b/projects/core/SseSubscriptionServer.ts
@@ -1,11 +1,39 @@
-import type { GenericRequestInfo, GenericResponse } from './server/index.js'
+import type {
+  GenericRequestInfo,
+  GenericResponse,
+} from './server/index.js'
+import type {
+  SubscriptionServerRouteApi,
+  SubscriptionServerWithRoutes,
+} from './server/remult-api-server.js'
 import type { Remult } from './src/context.js'
 import type { DataApiResponse } from './src/data-api.js'
 import { ConnectionNotFoundError } from './src/live-query/SseSubscriptionClient.js'
+import { streamUrl } from './src/live-query/SubscriptionChannel.js'
 import type { ServerEventChannelSubscribeDTO } from './src/live-query/SubscriptionChannel.js'
 import type { SubscriptionServer } from './src/live-query/SubscriptionServer.js'
 
-export class SseSubscriptionServer implements SubscriptionServer {
+export class SseSubscriptionServer implements SubscriptionServerWithRoutes {
+  initApiServer(api: SubscriptionServerRouteApi) {
+    const streamPath = '/' + streamUrl
+    api.addRoute(streamPath, 'get', async ({ req, origRes }) => {
+      this.openHttpServerStream(req, origRes as any)
+    })
+    api.addRoute(
+      streamPath + '/subscribe',
+      'post',
+      async ({ remult, res, getBody }) => {
+        this.subscribeToChannel(await getBody(), res, remult)
+      },
+    )
+    api.addRoute(
+      streamPath + '/unsubscribe',
+      'post',
+      async ({ remult, res, getBody }) => {
+        this.subscribeToChannel(await getBody(), res, remult, true)
+      },
+    )
+  }
   //@internal
   subscribeToChannel(
     { channel, clientId }: ServerEventChannelSubscribeDTO,

--- a/projects/core/SseSubscriptionServer.ts
+++ b/projects/core/SseSubscriptionServer.ts
@@ -1,7 +1,4 @@
-import type {
-  GenericRequestInfo,
-  GenericResponse,
-} from './server/index.js'
+import type { GenericRequestInfo, GenericResponse } from './server/index.js'
 import type {
   SubscriptionServerRouteApi,
   SubscriptionServerWithRoutes,
@@ -17,7 +14,10 @@ export class SseSubscriptionServer implements SubscriptionServerWithRoutes {
   initApiServer(api: SubscriptionServerRouteApi) {
     const streamPath = '/' + streamUrl
     api.addRoute(streamPath, 'get', async ({ req, origRes }) => {
-      this.openHttpServerStream(req, origRes as any)
+      this.openHttpServerStream(
+        req,
+        origRes as GenericResponse & ResponseRequiredForSSE,
+      )
     })
     api.addRoute(
       streamPath + '/subscribe',

--- a/projects/core/SseSubscriptionServer.ts
+++ b/projects/core/SseSubscriptionServer.ts
@@ -1,8 +1,5 @@
 import type { GenericRequestInfo, GenericResponse } from './server/index.js'
-import type {
-  SubscriptionServerRouteApi,
-  SubscriptionServerWithRoutes,
-} from './server/remult-api-server.js'
+import type { SubscriptionServerRouteApi } from './server/remult-api-server.js'
 import type { Remult } from './src/context.js'
 import type { DataApiResponse } from './src/data-api.js'
 import { ConnectionNotFoundError } from './src/live-query/SseSubscriptionClient.js'
@@ -10,7 +7,7 @@ import { streamUrl } from './src/live-query/SubscriptionChannel.js'
 import type { ServerEventChannelSubscribeDTO } from './src/live-query/SubscriptionChannel.js'
 import type { SubscriptionServer } from './src/live-query/SubscriptionServer.js'
 
-export class SseSubscriptionServer implements SubscriptionServerWithRoutes {
+export class SseSubscriptionServer implements SubscriptionServer {
   initApiServer(api: SubscriptionServerRouteApi) {
     const streamPath = '/' + streamUrl
     api.addRoute(streamPath, 'get', async ({ req, origRes }) => {

--- a/projects/core/internals.ts
+++ b/projects/core/internals.ts
@@ -25,6 +25,13 @@ export { isOfType } from './src/isOfType.js'
 
 export type { ClassType } from './classType.js'
 
+export type {
+  SubscriptionServerWithRoutes,
+  SubscriptionServerRouteApi,
+  SubscriptionServerRouteHandlerArgs,
+} from './server/remult-api-server.js'
+export type { DataApiResponse } from './src/data-api.js'
+
 export { flags } from './src/remult3/remult3.js'
 export { DataProviderPromiseWrapper } from './src/data-interfaces.js'
 export { pagedQueryResult } from './src/remult3/pagedQueryResult.js'

--- a/projects/core/internals.ts
+++ b/projects/core/internals.ts
@@ -26,7 +26,6 @@ export { isOfType } from './src/isOfType.js'
 export type { ClassType } from './classType.js'
 
 export type {
-  SubscriptionServerWithRoutes,
   SubscriptionServerRouteApi,
   SubscriptionServerRouteHandlerArgs,
 } from './server/remult-api-server.js'

--- a/projects/core/server/remult-api-server.ts
+++ b/projects/core/server/remult-api-server.ts
@@ -15,10 +15,7 @@ import type {
   ErrorInfo,
   Storage,
 } from '../src/data-interfaces.js'
-import {
-  liveQueryKeepAliveRoute,
-  streamUrl,
-} from '../src/live-query/SubscriptionChannel.js'
+import { liveQueryKeepAliveRoute } from '../src/live-query/SubscriptionChannel.js'
 import type {
   LiveQueryStorage,
   PerformWithContext,
@@ -287,6 +284,27 @@ export interface GenericResponse {
   end(): void
 }
 
+/** A `SubscriptionServer` that also needs to serve http routes (for example SSE),
+ * can implement this interface to register them on the api server */
+export interface SubscriptionServerWithRoutes extends SubscriptionServer {
+  initApiServer(api: SubscriptionServerRouteApi): void
+}
+export interface SubscriptionServerRouteApi {
+  rootPath: string
+  addRoute(
+    relativePath: string,
+    method: 'get' | 'post',
+    handler: (args: SubscriptionServerRouteHandlerArgs) => Promise<void>,
+  ): void
+}
+export interface SubscriptionServerRouteHandlerArgs {
+  remult: Remult
+  res: DataApiResponse
+  req: GenericRequestInfo
+  origRes: GenericResponse
+  getBody(): Promise<any>
+}
+
 /* @internal*/
 
 export class RemultServerImplementation<RequestType>
@@ -538,48 +556,37 @@ export class RemultServerImplementation<RequestType>
           res.success(remult.user ?? null),
         ),
       )
-      if (this.options.subscriptionServer instanceof SseSubscriptionServer) {
-        const streamPath = this.options.rootPath + '/' + streamUrl
-
-        r.route(streamPath).get(
-          this.process(async (remult, req, res, origReq, origRes) => {
-            ;(
-              remult.subscriptionServer as SseSubscriptionServer
-            ).openHttpServerStream(origReq, origRes as any)
-          }),
+      const subscriptionServer = this.options.subscriptionServer
+      if (
+        isOfType<SubscriptionServerWithRoutes>(
+          subscriptionServer,
+          'initApiServer',
         )
-        r.route(streamPath + '/subscribe').post(
-          this.process(async (remult, _2, res, _, _1, origReq: RequestType) => {
-            const body = (
-              remult.subscriptionServer as SseSubscriptionServer
-            ).subscribeToChannel(
-              await this.coreOptions.getRequestBody(origReq),
-              res,
-              remult,
+      ) {
+        subscriptionServer.initApiServer({
+          rootPath: this.options.rootPath!,
+          addRoute: (relativePath, method, handler) => {
+            r.route(this.options.rootPath + relativePath)[method](
+              this.process(
+                async (
+                  remult,
+                  _,
+                  res,
+                  req,
+                  origRes,
+                  origReq: RequestType,
+                ) =>
+                  handler({
+                    remult,
+                    res,
+                    req,
+                    origRes,
+                    getBody: () => this.coreOptions.getRequestBody(origReq),
+                  }),
+              ),
             )
-          }),
-        )
-        r.route(streamPath + '/unsubscribe').post(
-          this.process(
-            async (
-              remult,
-              req,
-              res,
-              reqInfo,
-              origRes,
-              origReq: RequestType,
-            ) => {
-              ;(
-                remult.subscriptionServer as SseSubscriptionServer
-              ).subscribeToChannel(
-                await this.coreOptions.getRequestBody(origReq),
-                res,
-                remult,
-                true,
-              )
-            },
-          ),
-        )
+          },
+        })
       }
       r.route(this.options.rootPath + '/' + liveQueryKeepAliveRoute).post(
         this.process(

--- a/projects/core/server/remult-api-server.ts
+++ b/projects/core/server/remult-api-server.ts
@@ -284,11 +284,6 @@ export interface GenericResponse {
   end(): void
 }
 
-/** A `SubscriptionServer` that also needs to serve http routes (for example SSE),
- * can implement this interface to register them on the api server */
-export interface SubscriptionServerWithRoutes extends SubscriptionServer {
-  initApiServer(api: SubscriptionServerRouteApi): void
-}
 export interface SubscriptionServerRouteApi {
   rootPath: string
   addRoute(
@@ -557,12 +552,7 @@ export class RemultServerImplementation<RequestType>
         ),
       )
       const subscriptionServer = this.options.subscriptionServer
-      if (
-        isOfType<SubscriptionServerWithRoutes>(
-          subscriptionServer,
-          'initApiServer',
-        )
-      ) {
+      if (subscriptionServer?.initApiServer) {
         subscriptionServer.initApiServer({
           rootPath: this.options.rootPath!,
           addRoute: (relativePath, method, handler) => {

--- a/projects/core/src/live-query/SubscriptionServer.ts
+++ b/projects/core/src/live-query/SubscriptionServer.ts
@@ -2,9 +2,13 @@ import type { itemChange } from '../context.js'
 import { findOptionsFromJson } from '../data-providers/rest-data-provider.js'
 import type { Repository } from '../remult3/remult3.js'
 import type { LiveQueryChange } from './SubscriptionChannel.js'
+import type { SubscriptionServerRouteApi } from '../../server/remult-api-server.js'
 
 export interface SubscriptionServer {
   publishMessage<T>(channel: string, message: T): Promise<void>
+  /** A subscription server that also needs to serve http routes (for example SSE),
+   * can implement this method to register them on the api server */
+  initApiServer?(api: SubscriptionServerRouteApi): void
 }
 
 /* @internal*/


### PR DESCRIPTION
## Summary
- Replace `instanceof SseSubscriptionServer` check in `remult-api-server.ts` with an inversion-of-control contract: any `SubscriptionServer` implementing `initApiServer(api)` (`SubscriptionServerWithRoutes`) can register its own http routes, so custom subscription servers can substitute SSE with anything.
- `SseSubscriptionServer` now registers its `/stream`, `/stream/subscribe`, `/stream/unsubscribe` routes itself via the new `SubscriptionServerRouteApi` (pure code move).
- New types (`SubscriptionServerWithRoutes`, `SubscriptionServerRouteApi`, `SubscriptionServerRouteHandlerArgs`, `DataApiResponse`) exported type-only from `remult/internals` while the contract evolves.
- Side benefit: duck typing (`isOfType`) survives npm-link / dual-package cases where `instanceof` breaks.

## Test plan
- [x] `tsc` build clean, `public-api.md` regenerated
- [x] Backend server tests pass: express (40), fastify (34), hono (34), koa (31+3 skipped)
- [x] Mutation-verified: disabling `initApiServer` registration makes the express live-query tests fail with 404s, confirming they exercise the new path
